### PR TITLE
Add Enter shortcut to open focused row in changelist page

### DIFF
--- a/src/django_admin_keyshortcuts/static/admin/js/shortcuts_changelist.js
+++ b/src/django_admin_keyshortcuts/static/admin/js/shortcuts_changelist.js
@@ -44,11 +44,38 @@
         actionsSelect.focus();
     }
 
+    /**
+     * Open the change form for the currently focused row (Issue #5).
+     *
+     * When a checkbox (j/k navigation) is focused, pressing Enter opens
+     * the change form link in the same row. This mimics the vi-like
+     * "open selected item" pattern.
+     */
+    function openFocusedRow() {
+        if (!currentCheckbox || currentCheckbox.id === 'action-toggle') {
+            return;
+        }
+        // The checkbox lives in a <td> inside a <tr>.
+        // The link to the change form is in the first <th> of the same <tr>.
+        const row = currentCheckbox.closest('tr');
+        if (!row) return;
+
+        const link = row.querySelector('th a');
+        if (link) {
+            link.click();
+        }
+    }
+
     function bindShortcutActionsToButtons() {
         document.getElementById("keyshortcut-prev-btn").addEventListener("click", focusPreviousCheckbox);
         document.getElementById("keyshortcut-next-btn").addEventListener("click", focusNextCheckbox);
         document.getElementById("keyshortcut-select-btn").addEventListener("click", selectCheckbox);
         document.getElementById("keyshortcut-select-actions-btn").addEventListener("click", selectActionsSelect);
+
+        const openRowBtn = document.getElementById("keyshortcut-open-row-btn");
+        if (openRowBtn) {
+            openRowBtn.addEventListener("click", openFocusedRow);
+        }
     }
 
     if (document.readyState === "loading") {
@@ -59,4 +86,3 @@
         bindShortcutActionsToButtons();
     }
 }
-

--- a/src/django_admin_keyshortcuts/templates/admin/change_list_shortcuts.html
+++ b/src/django_admin_keyshortcuts/templates/admin/change_list_shortcuts.html
@@ -9,6 +9,7 @@
   <button id="keyshortcut-next-btn" data-hotkey="{{ shortcuts.changelist.focus_next_row.1 }}" hidden></button>
   <button id="keyshortcut-select-btn" data-hotkey="{{ shortcuts.changelist.toggle_row_selection.1 }}" hidden></button>
   <button id="keyshortcut-select-actions-btn" data-hotkey="{{ shortcuts.changelist.focus_actions_dropdown.1 }}" hidden></button>
+  <button id="keyshortcut-open-row-btn" data-hotkey="{{ shortcuts.changelist.open_focused_row.1 }}" hidden></button>
 {% endblock %}
 
 {% block extra_shortcuts %}

--- a/src/django_admin_keyshortcuts/templatetags/shortcuts.py
+++ b/src/django_admin_keyshortcuts/templatetags/shortcuts.py
@@ -25,6 +25,7 @@ def get_shortcuts():
             "focus_actions_dropdown": (_("Focus actions dropdown"), "a"),
             "focus_search": (_("Focus search field"), "/"),
             "toggle_sidebar": (_("Toggle sidebar"), "["),
+            "open_focused_row": (_("Open focused row"), "Enter"),
         },
         "changeform": {
             "save": (_("Save"), "Mod+s"),


### PR DESCRIPTION
When navigating rows with j/k in the change list, pressing Enter now opens the change form for the currently focused row.

- Added openFocusedRow() function in shortcuts_changelist.js
- Added hidden button with data-hotkey='Enter' in change_list_shortcuts.html
- Added 'open_focused_row' entry to shortcuts dictionary in templatetags

Fixes khanxmetu/django-admin-keyshortcuts#5